### PR TITLE
GRADLE-3158 Cannot copy between different mount points with Gradle 2.0 o...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ libraries {
             } else if (targetPlatform.operatingSystem.linux) {
                 cppCompiler.args '-I', "${org.gradle.internal.jvm.Jvm.current().javaHome}/include"
                 cppCompiler.args '-I', "${org.gradle.internal.jvm.Jvm.current().javaHome}/include/linux"
+                cppCompiler.args '-D_FILE_OFFSET_BITS=64'
             } else if (targetPlatform.operatingSystem.windows) {
                 cppCompiler.args "-I${org.gradle.internal.jvm.Jvm.current().javaHome}/include"
                 cppCompiler.args "-I${org.gradle.internal.jvm.Jvm.current().javaHome}/include/win32"


### PR DESCRIPTION
...n Ubuntu

- use g++ compiler option '-D_FILE_OFFSET_BITS=64' to handle stat responses from Windows shares (64bit Inode values)