### PR TITLE
Prefer ncurses 6 over 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -356,11 +356,11 @@ String inferNCursesVersion(def os) {
         return "5"
     }
     for (def d: ["/lib", "/lib64", "/lib/x86_64-linux-gnu"]) {
-        if (new File("$d/libncurses.so.5").file) {
-            return "5"
-        }
         if (new File("$d/libncurses.so.6").file) {
             return "6"
+        }
+        if (new File("$d/libncurses.so.5").file) {
+            return "5"
         }
     }
     throw new IllegalArgumentException("Could not determine ncurses version installed on this machine.")


### PR DESCRIPTION
In most cases it should not make a difference (having both ncurses 6 and legacy 5 installed), however version 6 is newer and in a long run has a chance to contain some bug fixes and enhancements not available in version 5.