### PR TITLE
MemoryInfo implementation for MAC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,8 @@ task nativeHeaders {
             'net.rubygrapefruit.platform.internal.jni.WindowsFileFunctions',
             'net.rubygrapefruit.platform.internal.jni.FileEventFunctions',
             'net.rubygrapefruit.platform.internal.jni.PosixTypeFunctions',
-            'net.rubygrapefruit.platform.internal.jni.MemoryFunctions'
+            'net.rubygrapefruit.platform.internal.jni.MemoryFunctions',
+            'net.rubygrapefruit.platform.internal.jni.OsxMemoryFunctions'
     ]
     inputs.files sourceSets.main.output
     inputs.property('classes', classes)

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,8 @@ task nativeHeaders {
             'net.rubygrapefruit.platform.internal.jni.WindowsRegistryFunctions',
             'net.rubygrapefruit.platform.internal.jni.WindowsFileFunctions',
             'net.rubygrapefruit.platform.internal.jni.FileEventFunctions',
-            'net.rubygrapefruit.platform.internal.jni.PosixTypeFunctions'
+            'net.rubygrapefruit.platform.internal.jni.PosixTypeFunctions',
+            'net.rubygrapefruit.platform.internal.jni.MemoryFunctions'
     ]
     inputs.files sourceSets.main.output
     inputs.property('classes', classes)

--- a/src/main/cpp/apple.cpp
+++ b/src/main/cpp/apple.cpp
@@ -117,16 +117,14 @@ Java_net_rubygrapefruit_platform_internal_jni_MemoryFunctions_getMemoryInfo(JNIE
         return;
     }
 
-    // Calculate available system memory
-    // This is an approximation due to the Darwin VM model
-    // free + inactive - speculative pages
+    // Get VM stats
     vm_size_t page_size;
     mach_port_t mach_port;
     mach_msg_type_number_t count;
     vm_statistics64_data_t vm_stats;
 
     mach_port = mach_host_self();
-    count = sizeof(vm_stats) / sizeof(natural_t);
+    count = HOST_VM_INFO64_COUNT;
     if (KERN_SUCCESS != host_page_size(mach_port, &page_size)) {
         mark_failed_with_errno(env, "could not query page size", result);
         return;
@@ -135,11 +133,14 @@ Java_net_rubygrapefruit_platform_internal_jni_MemoryFunctions_getMemoryInfo(JNIE
         mark_failed_with_errno(env, "could not query host statistics", result);
         return;
     }
+
+    // Calculate available memory
     long long available_memory = ((int64_t)vm_stats.free_count
                                  + (int64_t)vm_stats.inactive_count
                                  - (int64_t)vm_stats.speculative_count)
                                  * (int64_t)page_size;
 
+    // Feed Java with details
     env->CallVoidMethod(dest, mid, (jlong)total_memory, (jlong)available_memory);
 }
 

--- a/src/main/cpp/apple.cpp
+++ b/src/main/cpp/apple.cpp
@@ -28,6 +28,9 @@
 #include <sys/mount.h>
 #include <unistd.h>
 #include <sys/attr.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <mach/mach.h>
 
 typedef struct vol_caps_buf {
     u_int32_t size;
@@ -89,6 +92,55 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixFileSystemFunctions_listFileS
         env->CallVoidMethod(info, method, mount_point, file_system_type, device_name, remote, caseSensitive, casePreserving);
     }
     free(buf);
+}
+
+/**
+ * Memory functions
+ */
+JNIEXPORT void JNICALL
+Java_net_rubygrapefruit_platform_internal_jni_MemoryFunctions_getMemoryInfo(JNIEnv *env, jclass type, jobject dest, jobject result) {
+    jclass destClass = env->GetObjectClass(dest);
+    jmethodID mid = env->GetMethodID(destClass, "details", "(JJ)V");
+    if (mid == NULL) {
+        mark_failed_with_message(env, "could not find method", result);
+        return;
+    }
+
+    // Get total physical memory
+    int mib[2];
+    mib[0] = CTL_HW;
+    mib[1] = HW_MEMSIZE;
+    int64_t total_memory = 0;
+    size_t len = sizeof(total_memory);
+    if (sysctl(mib, 2, &total_memory, &len, NULL, 0) != 0) {
+        mark_failed_with_errno(env, "could not query memory size", result);
+        return;
+    }
+
+    // Calculate available system memory
+    // This is an approximation due to the Darwin VM model
+    // free + inactive - speculative pages
+    vm_size_t page_size;
+    mach_port_t mach_port;
+    mach_msg_type_number_t count;
+    vm_statistics64_data_t vm_stats;
+
+    mach_port = mach_host_self();
+    count = sizeof(vm_stats) / sizeof(natural_t);
+    if (KERN_SUCCESS != host_page_size(mach_port, &page_size)) {
+        mark_failed_with_errno(env, "could not query page size", result);
+        return;
+    }
+    if (KERN_SUCCESS != host_statistics64(mach_port, HOST_VM_INFO, (host_info64_t)&vm_stats, &count)) {
+        mark_failed_with_errno(env, "could not query host statistics", result);
+        return;
+    }
+    long long available_memory = ((int64_t)vm_stats.free_count
+                                 + (int64_t)vm_stats.inactive_count
+                                 - (int64_t)vm_stats.speculative_count)
+                                 * (int64_t)page_size;
+
+    env->CallVoidMethod(dest, mid, (jlong)total_memory, (jlong)available_memory);
 }
 
 #endif

--- a/src/main/java/net/rubygrapefruit/platform/Memory.java
+++ b/src/main/java/net/rubygrapefruit/platform/Memory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform;
+
+@ThreadSafe
+public interface Memory extends NativeIntegration {
+    /**
+     * Queries the current state of the system memory.
+     *
+     * @throws NativeException On failure.
+     */
+    @ThreadSafe
+    MemoryInfo getMemoryInfo() throws NativeException;
+}

--- a/src/main/java/net/rubygrapefruit/platform/MemoryInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/MemoryInfo.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform;
+
+/**
+ * Provides some information about the system memory. This is a snapshot and does not change.
+ */
+public interface MemoryInfo {
+    /**
+     * Returns the number of bytes of physical memory installed in the machine.
+     */
+    long getTotalPhysicalMemory();
+
+    /**
+     * Returns the number of bytes of physical memory that are available for use. Includes memory that is available without swapping.
+     */
+    long getAvailablePhysicalMemory();
+}

--- a/src/main/java/net/rubygrapefruit/platform/OsxMemory.java
+++ b/src/main/java/net/rubygrapefruit/platform/OsxMemory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform;
+
+@ThreadSafe
+public interface OsxMemory extends NativeIntegration {
+    /**
+     * Queries the current state of the system memory.
+     *
+     * @throws NativeException On failure.
+     */
+    @ThreadSafe
+    OsxMemoryInfo getMemoryInfo() throws NativeException;
+}

--- a/src/main/java/net/rubygrapefruit/platform/OsxMemoryInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/OsxMemoryInfo.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform;
+
+/**
+ * Detailed OSX memory info.
+ *
+ * <strong>This is not exactly what {@literal vm_stat} displays:</strong>
+ *
+ * {@literal vm_stat}'s {@literal Free pages}
+ * is {@link #getFreePagesCount()} minus {@link #getSpeculativePagesCount()}.
+ *
+ * {@link #getExternalPagesCount()} is displayed as {@literal File-backed pages}.
+ */
+public interface OsxMemoryInfo {
+    long getPageSize();
+
+    long getFreePagesCount();
+
+    long getInactivePagesCount();
+
+    long getWiredPagesCount();
+
+    long getActivePagesCount();
+
+    long getExternalPagesCount();
+
+    long getSpeculativePagesCount();
+
+    long getTotalPhysicalMemory();
+
+    /**
+     * Calculated.
+     */
+    long getAvailablePhysicalMemory();
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/DefaultMemory.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/DefaultMemory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal;
+
+import net.rubygrapefruit.platform.Memory;
+import net.rubygrapefruit.platform.MemoryInfo;
+import net.rubygrapefruit.platform.NativeException;
+import net.rubygrapefruit.platform.internal.jni.MemoryFunctions;
+
+public class DefaultMemory implements Memory {
+    public MemoryInfo getMemoryInfo() {
+        FunctionResult result = new FunctionResult();
+        DefaultMemoryInfo memoryInfo = new DefaultMemoryInfo();
+        MemoryFunctions.getMemoryInfo(memoryInfo, result);
+        if (result.isFailed()) {
+            throw new NativeException(String.format("Could not get system memory info: %s", result.getMessage()));
+        }
+        return memoryInfo;
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/DefaultMemoryInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/DefaultMemoryInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal;
+
+import net.rubygrapefruit.platform.MemoryInfo;
+
+public class DefaultMemoryInfo implements MemoryInfo {
+    private long totalMem;
+    private long availableMem;
+
+    public void details(long totalMem, long availableMem) {
+        this.totalMem = totalMem;
+        this.availableMem = availableMem;
+    }
+
+    public long getTotalPhysicalMemory() {
+        return totalMem;
+    }
+
+    public long getAvailablePhysicalMemory() {
+        return availableMem;
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/DefaultOsxMemory.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/DefaultOsxMemory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal;
+
+import net.rubygrapefruit.platform.NativeException;
+import net.rubygrapefruit.platform.OsxMemory;
+import net.rubygrapefruit.platform.OsxMemoryInfo;
+import net.rubygrapefruit.platform.internal.jni.OsxMemoryFunctions;
+
+public class DefaultOsxMemory implements OsxMemory {
+    public OsxMemoryInfo getMemoryInfo() throws NativeException {
+        FunctionResult result = new FunctionResult();
+        DefaultOsxMemoryInfo memoryInfo = new DefaultOsxMemoryInfo();
+        OsxMemoryFunctions.getOsxMemoryInfo(memoryInfo, result);
+        if (result.isFailed()) {
+            throw new NativeException(String.format("Could not get OSX memory info: %s", result.getMessage()));
+        }
+        return memoryInfo;
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/DefaultOsxMemoryInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/DefaultOsxMemoryInfo.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal;
+
+import net.rubygrapefruit.platform.OsxMemoryInfo;
+
+public class DefaultOsxMemoryInfo implements OsxMemoryInfo {
+    private long pageSize;
+    private long freeCount;
+    private long inactiveCount;
+    private long wiredCount;
+    private long activeCount;
+    private long externalCount;
+    private long speculativeCount;
+
+    private long totalMem;
+    private long availableMem;
+
+    public void details(long pageSize,
+                        long freeCount,
+                        long inactiveCount,
+                        long wiredCount,
+                        long activeCount,
+                        long externalCount,
+                        long speculativeCount,
+                        long totalMem,
+                        long availableMem) {
+        this.pageSize = pageSize;
+        this.freeCount = freeCount;
+        this.inactiveCount = inactiveCount;
+        this.wiredCount = wiredCount;
+        this.activeCount = activeCount;
+        this.externalCount = externalCount;
+        this.speculativeCount = speculativeCount;
+        this.totalMem = totalMem;
+        this.availableMem = availableMem;
+    }
+
+    public long getPageSize() {
+        return pageSize;
+    }
+
+    public long getFreePagesCount() {
+        return freeCount;
+    }
+
+    public long getInactivePagesCount() {
+        return inactiveCount;
+    }
+
+    public long getWiredPagesCount() {
+        return wiredCount;
+    }
+
+    public long getActivePagesCount() {
+        return activeCount;
+    }
+
+    public long getExternalPagesCount() {
+        return externalCount;
+    }
+
+    public long getSpeculativePagesCount() {
+        return speculativeCount;
+    }
+
+    public long getTotalPhysicalMemory() {
+        return totalMem;
+    }
+
+    public long getAvailablePhysicalMemory() {
+        return availableMem;
+    }
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -301,6 +301,9 @@ public abstract class Platform {
 
         @Override
         public <T extends NativeIntegration> T get(Class<T> type, NativeLibraryLoader nativeLibraryLoader) {
+            if (type.equals(OsxMemory.class)) {
+                return type.cast(new DefaultOsxMemory());
+            }
             if (type.equals(Memory.class)) {
                 return type.cast(new DefaultMemory());
             }

--- a/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -298,6 +298,14 @@ public abstract class Platform {
         String getCursesLibraryName() {
             return "libnative-platform-curses.dylib";
         }
+
+        @Override
+        public <T extends NativeIntegration> T get(Class<T> type, NativeLibraryLoader nativeLibraryLoader) {
+            if (type.equals(Memory.class)) {
+                return type.cast(new DefaultMemory());
+            }
+            return super.get(type, nativeLibraryLoader);
+        }
     }
 
     private static class OsX32Bit extends OsX {

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/MemoryFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/MemoryFunctions.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal.jni;
+
+import net.rubygrapefruit.platform.internal.DefaultMemoryInfo;
+import net.rubygrapefruit.platform.internal.FunctionResult;
+
+public class MemoryFunctions {
+    public static native void getMemoryInfo(DefaultMemoryInfo memoryInfo, FunctionResult result);
+}

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxMemoryFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/OsxMemoryFunctions.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform.internal.jni;
+
+import net.rubygrapefruit.platform.internal.DefaultOsxMemoryInfo;
+import net.rubygrapefruit.platform.internal.FunctionResult;
+
+public class OsxMemoryFunctions {
+    public static native void getOsxMemoryInfo(DefaultOsxMemoryInfo memoryInfo, FunctionResult result);
+}

--- a/src/test/groovy/net/rubygrapefruit/platform/MemoryTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/MemoryTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform
+
+import java.lang.management.ManagementFactory
+import net.rubygrapefruit.platform.internal.Platform
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+@IgnoreIf({ Platform.current().linux || Platform.current().windows })
+class MemoryTest extends Specification {
+    def "caches memory instance"() {
+        expect:
+        def memory = Native.get(Memory.class)
+        memory.is(Native.get(Memory.class))
+    }
+
+    def "can query system memory"() {
+        expect:
+        def memory = Native.get(Memory.class)
+
+        def memoryInfo = memory.memoryInfo
+        memoryInfo.totalPhysicalMemory > 0
+        memoryInfo.availablePhysicalMemory > 0
+        memoryInfo.availablePhysicalMemory <= memoryInfo.totalPhysicalMemory
+        memoryInfo.totalPhysicalMemory == jmxTotalPhysicalMemory
+        memoryInfo.availablePhysicalMemory > jmxAvailablePhysicalMemory
+    }
+
+    long getJmxTotalPhysicalMemory() {
+        ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
+    }
+
+    long getJmxAvailablePhysicalMemory() {
+        ManagementFactory.operatingSystemMXBean.freePhysicalMemorySize
+    }
+}

--- a/src/test/groovy/net/rubygrapefruit/platform/MemoryTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/MemoryTest.groovy
@@ -35,17 +35,12 @@ class MemoryTest extends Specification {
 
         def memoryInfo = memory.memoryInfo
         memoryInfo.totalPhysicalMemory > 0
+        memoryInfo.totalPhysicalMemory == jmxTotalPhysicalMemory
         memoryInfo.availablePhysicalMemory > 0
         memoryInfo.availablePhysicalMemory <= memoryInfo.totalPhysicalMemory
-        memoryInfo.totalPhysicalMemory == jmxTotalPhysicalMemory
-        memoryInfo.availablePhysicalMemory > jmxAvailablePhysicalMemory
     }
 
     long getJmxTotalPhysicalMemory() {
         ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
-    }
-
-    long getJmxAvailablePhysicalMemory() {
-        ManagementFactory.operatingSystemMXBean.freePhysicalMemorySize
     }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/OsxMemoryTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/OsxMemoryTest.groovy
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2012 Adam Murdoch
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.rubygrapefruit.platform
+
+import java.lang.management.ManagementFactory
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+import net.rubygrapefruit.platform.internal.DefaultOsxMemoryInfo
+import net.rubygrapefruit.platform.internal.Platform
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+@IgnoreIf({Platform.current().linux || Platform.current().windows})
+class OsxMemoryTest extends Specification {
+
+  def "caches memory instance"() {
+    expect:
+    def memory = Native.get(OsxMemory.class)
+    memory.is(Native.get(OsxMemory.class))
+  }
+
+  def "can query OSX memory info"() {
+    given:
+    def memory = Native.get(OsxMemory.class)
+
+    when:
+    def vmStatInfo = getFromVmStatCommand()
+    def memoryInfo = memory.memoryInfo
+
+    and:
+    def csv = toCsv(memoryInfo, vmStatInfo)
+    println csv
+
+    then:
+    memoryInfo.totalPhysicalMemory > 0
+    memoryInfo.availablePhysicalMemory > 0
+    memoryInfo.availablePhysicalMemory <= memoryInfo.totalPhysicalMemory
+    memoryInfo.totalPhysicalMemory == jmxTotalPhysicalMemory
+    memoryInfo.availablePhysicalMemory > jmxAvailablePhysicalMemory
+  }
+
+  @Ignore
+  def "indefinitely sample OSX memory info"() {
+    given:
+    def memory = Native.get(OsxMemory.class)
+    def conditions = new PollingConditions(timeout: Double.MAX_VALUE, initialDelay: 5, delay: 5)
+
+    expect:
+    conditions.eventually {
+      def vmStatInfo = getFromVmStatCommand()
+      def memoryInfo = memory.memoryInfo
+
+      def csv = toCsv(memoryInfo, vmStatInfo)
+      println csv
+      new File("/tmp/osx-memory-sampling-${ System.currentTimeMillis() }.csv").text = csv
+
+      assert false
+    }
+  }
+
+  def toCsv(OsxMemoryInfo hostStat, OsxMemoryInfo vmStat)
+  {
+    assert hostStat.pageSize == vmStat.pageSize
+    def pageSize = hostStat.pageSize
+    def mb = { long pages ->
+      (int) pageSize * pages / 1024 / 1024
+    }
+    def row = { String title, long nativePages, long vmStatPages ->
+      "$title,$nativePages,${ mb nativePages },${ mb vmStatPages },$vmStatPages\n"
+    }
+    def csv = "value,host_statistics_pages,host_statistics_mb,vm_stat_mb,vm_stat_pages\n"
+    csv += row 'free', hostStat.freePagesCount, vmStat.freePagesCount
+    csv += row 'inactive', hostStat.inactivePagesCount, vmStat.inactivePagesCount
+    csv += row 'wired', hostStat.wiredPagesCount, vmStat.wiredPagesCount
+    csv += row 'active', hostStat.activePagesCount, vmStat.activePagesCount
+    csv += row 'external', hostStat.externalPagesCount, vmStat.externalPagesCount
+    csv += row 'speculative', hostStat.speculativePagesCount, vmStat.speculativePagesCount
+    csv += row 'total',
+               (long) hostStat.totalPhysicalMemory / pageSize,
+               (long) vmStat.totalPhysicalMemory / pageSize
+    csv += row 'available_fcache',
+               hostStat.freePagesCount + hostStat.externalPagesCount - hostStat.speculativePagesCount,
+               vmStat.freePagesCount + vmStat.externalPagesCount - vmStat.speculativePagesCount
+    csv += row 'available_inact',
+               hostStat.freePagesCount + hostStat.inactivePagesCount - hostStat.speculativePagesCount,
+               vmStat.freePagesCount + vmStat.inactivePagesCount - vmStat.speculativePagesCount
+    return csv
+  }
+
+  long getJmxTotalPhysicalMemory() {
+    ManagementFactory.operatingSystemMXBean.totalPhysicalMemorySize
+  }
+
+  long getJmxAvailablePhysicalMemory() {
+    ManagementFactory.operatingSystemMXBean.freePhysicalMemorySize
+  }
+
+  def VMSTAT_LINE_PATTERN = Pattern.compile(/^\D+(\d+)\D+$/)
+  def vmstatMatcher = VMSTAT_LINE_PATTERN.matcher( "" )
+
+  OsxMemoryInfo getFromVmStatCommand() {
+    def output = "vm_stat".execute().text
+    def lines = output.readLines()
+    long pageSize = parseVmstatPages lines.get(0)
+    long freeCount = 0
+    long inactiveCount = 0
+    long wiredCount = 0
+    long activeCount = 0
+    long externalCount = 0
+    long speculativeCount = 0
+    lines.drop(1).each { line ->
+      if (line.startsWith("Pages free"))
+      {
+        freeCount += parseVmstatPages line
+      }
+      else if (line.startsWith("Pages inactive"))
+      {
+        inactiveCount = parseVmstatPages line
+      }
+      else if (line.startsWith("Pages wired"))
+      {
+        wiredCount = parseVmstatPages line
+      }
+      else if (line.startsWith("Pages active"))
+      {
+        activeCount = parseVmstatPages line
+      }
+      else if (line.startsWith("File-backed pages"))
+      {
+        externalCount = parseVmstatPages line
+      }
+      else if (line.startsWith("Pages speculative"))
+      {
+        speculativeCount = parseVmstatPages line
+        freeCount += speculativeCount
+      }
+    }
+    long totalMem = jmxTotalPhysicalMemory
+    long availableMem = (freeCount + externalCount) * pageSize
+    DefaultOsxMemoryInfo info = new DefaultOsxMemoryInfo()
+    info.details(pageSize,
+                 freeCount, inactiveCount,
+                 wiredCount, activeCount,
+                 externalCount,
+                 speculativeCount,
+                 totalMem,
+                 availableMem)
+    return info
+  }
+
+  private long parseVmstatPages(String line) {
+    Matcher matcher = vmstatMatcher.reset line
+    if (matcher.matches()) {
+      return Long.parseLong(matcher.group(1))
+    }
+    throw new UnsupportedOperationException("Unable to parse vm_stat output")
+  }
+}


### PR DESCRIPTION
Uses `sysctl` to query total physical memory.

Uses `host_statistics64` to calculate available physical memory (`free_count + inactive_count - speculative_count`).

Do not rely on `external_page_count` which should be the file cache because it is available since OSX 10.9 only and it shown inaccurate (larger than total memory) values with long uptime or under load.

Subtract `speculative` in order to provide a pessimistic result rather than an optimistic one.