### PR TITLE
Allow stat() to handle paths that happen to match an existing file 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,6 @@ def ncursesVersion = inferNCursesVersion(os)
 
 model {
     platforms {
-        osx_i386 {
-            architecture "i386"
-            operatingSystem "osx"
-        }
         osx_amd64 {
             architecture "amd64"
             operatingSystem "osx"
@@ -256,8 +252,8 @@ model {
                 if (targetPlatform.operatingSystem.macOsX) {
                     cppCompiler.args '-I', "${org.gradle.internal.jvm.Jvm.current().javaHome}/include"
                     cppCompiler.args '-I', "${org.gradle.internal.jvm.Jvm.current().javaHome}/include/darwin"
-                    cppCompiler.args '-mmacosx-version-min=10.4'
-                    linker.args '-mmacosx-version-min=10.4'
+                    cppCompiler.args '-mmacosx-version-min=10.9'
+                    linker.args '-mmacosx-version-min=10.9'
                 } else if (targetPlatform.operatingSystem.linux) {
                     cppCompiler.args '-I', "${org.gradle.internal.jvm.Jvm.current().javaHome}/include"
                     cppCompiler.args '-I', "${org.gradle.internal.jvm.Jvm.current().javaHome}/include/linux"

--- a/src/main/cpp/freebsd_kevents.cpp
+++ b/src/main/cpp/freebsd_kevents.cpp
@@ -75,7 +75,7 @@ Java_net_rubygrapefruit_platform_internal_jni_FileEventFunctions_waitForNextEven
     watch_details_t* details = (watch_details_t*)env->GetDirectBufferAddress(handle);
     struct kevent event;
     int event_count = kevent(details->watch_fd, NULL, 0, &event, 1, NULL);
-    if (event_count < 0 && errno == EINTR) {
+    if (event_count < 0 && (errno == EINTR || errno == EBADF)) {
         return JNI_FALSE;
     }
     if ((event_count < 0) || (event.flags == EV_ERROR)) {

--- a/src/main/cpp/posix.cpp
+++ b/src/main/cpp/posix.cpp
@@ -128,7 +128,7 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixFileFunctions_stat(JNIEnv *en
         retval = lstat(pathStr, &fileInfo);
     }
     free(pathStr);
-    if (retval != 0 && errno != ENOENT) {
+    if (retval != 0 && errno != ENOENT && errno != ENOTDIR) {
         mark_failed_with_errno(env, "could not stat file", result);
         return;
     }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
@@ -28,10 +28,14 @@ class AbstractFilesTest extends Specification {
         return java.nio.file.Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes()
     }
 
-    long toJavaFileTime(long time) {
-        if (Platform.current().isLinux()) {
+    private long toJavaFileTime(long time) {
+        if (Platform.current().isLinux() || Platform.current().isMacOs()) {
             return (time / 1000).longValue() * 1000 // round to nearest second
         }
         return time
+    }
+
+    void assertTimestampMatches(long statTime, long javaTime) {
+        assert toJavaFileTime(statTime) == javaTime
     }
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
@@ -17,10 +17,13 @@ package net.rubygrapefruit.platform.file
 
 import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.internal.Platform
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.IgnoreIf
 import spock.lang.Shared
+
+import static org.junit.Assume.assumeFalse
 
 class FilesTest extends AbstractFilesTest {
     @Shared
@@ -40,6 +43,8 @@ class FilesTest extends AbstractFilesTest {
     }
 
     def "can stat a file"() {
+        assumeFalse(Platform.current().windows && fileName.size() > 260)
+
         def dir = tmpDir.newFolder()
         def testFile = new File(dir, fileName)
         testFile.parentFile.mkdirs()
@@ -78,6 +83,8 @@ class FilesTest extends AbstractFilesTest {
     }
 
     def "can stat a directory"() {
+        assumeFalse(Platform.current().windows && fileName.size() > 260)
+
         def dir = tmpDir.newFolder()
         def testFile = new File(dir, fileName)
         testFile.mkdirs()
@@ -281,6 +288,8 @@ class FilesTest extends AbstractFilesTest {
     }
 
     def "can list contents of an empty directory"() {
+        assumeFalse(Platform.current().windows && fileName.size() > 260)
+
         def dir = tmpDir.newFolder()
         def testFile = new File(dir, fileName)
         testFile.mkdirs()
@@ -296,6 +305,8 @@ class FilesTest extends AbstractFilesTest {
     }
 
     def "can list contents of a directory"() {
+        assumeFalse(Platform.current().windows && fileName.size() > 260)
+
         def dir = tmpDir.newFolder()
         def testFile = new File(dir, fileName)
         testFile.mkdirs()

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
@@ -52,8 +52,8 @@ class FilesTest extends AbstractFilesTest {
         then:
         stat.type == FileInfo.Type.File
         stat.size == 2
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
 
         where:
         fileName << names
@@ -70,8 +70,8 @@ class FilesTest extends AbstractFilesTest {
         then:
         stat.type == FileInfo.Type.File
         stat.size == 2
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
 
         where:
         followLinks << [true, false]
@@ -89,8 +89,8 @@ class FilesTest extends AbstractFilesTest {
         then:
         stat.type == FileInfo.Type.Directory
         stat.size == 0
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
 
         where:
         fileName << names
@@ -106,8 +106,8 @@ class FilesTest extends AbstractFilesTest {
         then:
         stat.type == FileInfo.Type.Directory
         stat.size == 0
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
 
         where:
         followLinks << [true, false]
@@ -318,15 +318,15 @@ class FilesTest extends AbstractFilesTest {
         dirEntry.type == FileInfo.Type.Directory
         dirEntry.name == childDir.name
         dirEntry.size == 0L
-        dirEntry.lastModifiedTime == childDirAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(dirEntry.lastModifiedTime) == childDir.lastModified()
+        assertTimestampMatches(dirEntry.lastModifiedTime, childDirAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(dirEntry.lastModifiedTime, childDir.lastModified())
 
         def fileEntry = files[1]
         fileEntry.type == FileInfo.Type.File
         fileEntry.name == childFile.name
         fileEntry.size == 8
-        fileEntry.lastModifiedTime == childFileAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(fileEntry.lastModifiedTime) == childFile.lastModified()
+        assertTimestampMatches(fileEntry.lastModifiedTime, childFileAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(fileEntry.lastModifiedTime, childFile.lastModified())
 
         where:
         fileName << names
@@ -352,15 +352,15 @@ class FilesTest extends AbstractFilesTest {
         dirEntry.type == FileInfo.Type.Directory
         dirEntry.name == childDir.name
         dirEntry.size == 0L
-        dirEntry.lastModifiedTime == childDirAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(dirEntry.lastModifiedTime) == childDir.lastModified()
+        assertTimestampMatches(dirEntry.lastModifiedTime, childDirAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(dirEntry.lastModifiedTime, childDir.lastModified())
 
         def fileEntry = files[1]
         fileEntry.type == FileInfo.Type.File
         fileEntry.name == childFile.name
         fileEntry.size == 8
-        fileEntry.lastModifiedTime == childFileAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(fileEntry.lastModifiedTime) == childFile.lastModified()
+        assertTimestampMatches(fileEntry.lastModifiedTime, childFileAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(fileEntry.lastModifiedTime, childFile.lastModified())
 
         where:
         followLinks << [true, false]

--- a/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/FilesTest.groovy
@@ -148,6 +148,25 @@ class FilesTest extends AbstractFilesTest {
         fileName << names
     }
 
+    def "can stat a missing file when something in the path matches an existing file"() {
+        def testDir = tmpDir.newFile(dirName)
+        def testFile = new File(testDir, fileName)
+
+        when:
+        def stat = files.stat(testFile)
+
+        then:
+        stat.type == FileInfo.Type.Missing
+        stat.size == 0
+        stat.lastModifiedTime == 0
+
+        where:
+        dirName                | fileName
+        "test-dir"             | "test-file"
+        "test\u03b1\u2295-dir" | "test-file"
+        "test-dir1"            | "test-dir2/test-file"
+    }
+
     def "follow links has no effect for stat of a missing file"() {
         def testFile = new File(tmpDir.root, "nested/missing")
 

--- a/src/test/groovy/net/rubygrapefruit/platform/file/PosixFilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/PosixFilesTest.groovy
@@ -103,6 +103,29 @@ class PosixFilesTest extends AbstractFilesTest {
         fileName << ["test-dir", "test\u03b1\u2295-dir"]
     }
 
+    def "can stat a missing file when something in the path matches an existing file"() {
+        def testDir = tmpDir.newFile(dirName)
+        def testFile = new File(testDir, fileName)
+
+        when:
+        def stat = files.stat(testFile)
+
+        then:
+        stat.type == FileInfo.Type.Missing
+        stat.mode == 0
+        stat.uid == 0
+        stat.gid == 0
+        stat.size == 0
+        stat.lastModifiedTime == 0
+        stat.blockSize == 0
+
+        where:
+        dirName                | fileName
+        "test-dir"             | "test-file"
+        "test\u03b1\u2295-dir" | "test-file"
+        "test-dir1"            | "test-dir2/test-file"
+    }
+
     def "can stat a file with no read permissions"() {
         def testFile = tmpDir.newFile("test.file")
         chmod(testFile, [OWNER_WRITE])

--- a/src/test/groovy/net/rubygrapefruit/platform/file/PosixFilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/PosixFilesTest.groovy
@@ -55,8 +55,8 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == testFile.size()
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
         stat.blockSize
 
         where:
@@ -76,8 +76,8 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
         stat.blockSize
 
         where:
@@ -182,7 +182,7 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == linkAttributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(stat.lastModifiedTime, linkAttributes.lastModifiedTime().toMillis())
         stat.blockSize
 
         when:
@@ -194,7 +194,7 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == linkAttributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(stat.lastModifiedTime, linkAttributes.lastModifiedTime().toMillis())
         stat.blockSize
 
         when:
@@ -206,8 +206,8 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == dirAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == dir.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, dirAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, dir.lastModified())
         stat.blockSize
 
         where:
@@ -234,7 +234,7 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == linkAttributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(stat.lastModifiedTime, linkAttributes.lastModifiedTime().toMillis())
         stat.blockSize
 
         when:
@@ -246,7 +246,7 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == linkAttributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(stat.lastModifiedTime, linkAttributes.lastModifiedTime().toMillis())
         stat.blockSize
 
         when:
@@ -258,8 +258,8 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == file.length()
-        stat.lastModifiedTime == fileAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == file.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, fileAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, file.lastModified())
         stat.blockSize
 
         where:
@@ -282,7 +282,7 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
         stat.blockSize
 
         when:
@@ -294,7 +294,7 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.uid != 0
         stat.gid >= 0
         stat.size == 0
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
         stat.blockSize
 
         when:
@@ -377,8 +377,8 @@ class PosixFilesTest extends AbstractFilesTest {
         stat.mode == mode(attributes)
         stat.uid != 0
         stat.gid >= 0
-        stat.lastModifiedTime == attributes.lastModifiedTime().toMillis()
-        toJavaFileTime(stat.lastModifiedTime) == testFile.lastModified()
+        assertTimestampMatches(stat.lastModifiedTime, attributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(stat.lastModifiedTime, testFile.lastModified())
         stat.blockSize
 
         where:
@@ -413,21 +413,21 @@ class PosixFilesTest extends AbstractFilesTest {
         dirEntry.type == FileInfo.Type.Directory
         dirEntry.name == childDir.name
         dirEntry.size == 0
-        dirEntry.lastModifiedTime == childDirAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(dirEntry.lastModifiedTime) == childDir.lastModified()
+        assertTimestampMatches(dirEntry.lastModifiedTime, childDirAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(dirEntry.lastModifiedTime, childDir.lastModified())
 
         def fileEntry = entries[1]
         fileEntry.type == FileInfo.Type.File
         fileEntry.name == childFile.name
         fileEntry.size == childFile.length()
-        fileEntry.lastModifiedTime == childFileAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(fileEntry.lastModifiedTime) == childFile.lastModified()
+        assertTimestampMatches(fileEntry.lastModifiedTime, childFileAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(fileEntry.lastModifiedTime, childFile.lastModified())
 
         def linkEntry = entries[2]
         linkEntry.type == FileInfo.Type.Symlink
         linkEntry.name == childLink.name
         linkEntry.size == 0
-        linkEntry.lastModifiedTime == childLinkAttributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(linkEntry.lastModifiedTime, childLinkAttributes.lastModifiedTime().toMillis())
 
         when:
         entries = files.listDir(dir, false)
@@ -440,21 +440,21 @@ class PosixFilesTest extends AbstractFilesTest {
         dirEntry2.type == FileInfo.Type.Directory
         dirEntry2.name == childDir.name
         dirEntry2.size == 0
-        dirEntry2.lastModifiedTime == childDirAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(dirEntry2.lastModifiedTime) == childDir.lastModified()
+        assertTimestampMatches(dirEntry2.lastModifiedTime, childDirAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(dirEntry2.lastModifiedTime, childDir.lastModified())
 
         def fileEntry2 = entries[1]
         fileEntry2.type == FileInfo.Type.File
         fileEntry2.name == childFile.name
         fileEntry2.size == childFile.length()
-        fileEntry2.lastModifiedTime == childFileAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(fileEntry2.lastModifiedTime) == childFile.lastModified()
+        assertTimestampMatches(fileEntry2.lastModifiedTime, childFileAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(fileEntry2.lastModifiedTime, childFile.lastModified())
 
         def linkEntry2 = entries[2]
         linkEntry2.type == FileInfo.Type.Symlink
         linkEntry2.name == childLink.name
         linkEntry2.size == 0
-        linkEntry2.lastModifiedTime == childLinkAttributes.lastModifiedTime().toMillis()
+        assertTimestampMatches(linkEntry2.lastModifiedTime, childLinkAttributes.lastModifiedTime().toMillis())
 
         when:
         entries = files.listDir(dir, true)
@@ -467,22 +467,22 @@ class PosixFilesTest extends AbstractFilesTest {
         dirEntry3.type == FileInfo.Type.Directory
         dirEntry3.name == childDir.name
         dirEntry3.size == 0
-        dirEntry3.lastModifiedTime == childDirAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(dirEntry3.lastModifiedTime) == childDir.lastModified()
+        assertTimestampMatches(dirEntry3.lastModifiedTime, childDirAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(dirEntry3.lastModifiedTime, childDir.lastModified())
 
         def fileEntry3 = entries[1]
         fileEntry3.type == FileInfo.Type.File
         fileEntry3.name == childFile.name
         fileEntry3.size == childFile.length()
-        fileEntry3.lastModifiedTime == childFileAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(fileEntry3.lastModifiedTime) == childFile.lastModified()
+        assertTimestampMatches(fileEntry3.lastModifiedTime, childFileAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(fileEntry3.lastModifiedTime, childFile.lastModified())
 
         def linkEntry3 = entries[2]
         linkEntry3.type == FileInfo.Type.File
         linkEntry3.name == childLink.name
         linkEntry3.size == linkTarget.length()
-        linkEntry3.lastModifiedTime == linkTargetAttributes.lastModifiedTime().toMillis()
-        toJavaFileTime(linkEntry3.lastModifiedTime) == linkTarget.lastModified()
+        assertTimestampMatches(linkEntry3.lastModifiedTime, linkTargetAttributes.lastModifiedTime().toMillis())
+        assertTimestampMatches(linkEntry3.lastModifiedTime, linkTarget.lastModified())
 
         where:
         fileName << ["test-dir", "test\u03b1\u2295-dir"]


### PR DESCRIPTION
There are a couple of things in this pull request:

- Changes so that `stat()` does not return an exception when something in the path happens to match some existing file.  It now treats it like the path is not found rather than an error.
- Changes to build with Xcode10 on OSX.  This also drops support for OSX 32-bit.
- Some updates/refactors to tests to get them to pass on various platforms:
  - Ignore the test for file names longer than the 260 character max on windows.
  - Resolve the timestamp difference between `stat()` and java file methods on macOS.
  - Fix an issue on OSX/jdk8 where closing the file watch was causing an EBADF instead of EINTR when polling for the next change.

The tests all pass for me now on both jdk7 and jdk8 on OSX, Linux and Windows.  I did not find any jvm-specific differences that seemed to require any special handling (at least on the OS/JVM combinations I tested with).
