### PR TITLE
Always round timestamps on linux/OSX

### DIFF
--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
@@ -28,7 +28,7 @@ class AbstractFilesTest extends Specification {
         return java.nio.file.Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes()
     }
 
-    private long toJavaFileTime(long time) {
+    private long maybeRoundToNearestSecond(long time) {
         if (Platform.current().isLinux() || Platform.current().isMacOs()) {
             return (time / 1000).longValue() * 1000 // round to nearest second
         }
@@ -36,6 +36,7 @@ class AbstractFilesTest extends Specification {
     }
 
     void assertTimestampMatches(long statTime, long javaTime) {
-        assert toJavaFileTime(statTime) == javaTime
+        def props = System.getProperties()
+        assert maybeRoundToNearestSecond(statTime) == maybeRoundToNearestSecond(javaTime)
     }
 }


### PR DESCRIPTION
Fixes difference between oracle jdk 8 and openjdk 8.