### PR TITLE
Resolve issues with supplementary characters being set in environment variables

### DIFF
--- a/src/main/cpp/posix.cpp
+++ b/src/main/cpp/posix.cpp
@@ -328,16 +328,20 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixProcessFunctions_getEnvironme
 JNIEXPORT void JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_PosixProcessFunctions_setEnvironmentVariable(JNIEnv *env, jclass target, jstring var, jstring value, jobject result) {
     char* varStr = java_to_char(env, var, result);
-    if (value == NULL) {
-        if (setenv(varStr, "", 1) != 0) {
-            mark_failed_with_errno(env, "could not putenv()", result);
+    if (varStr != NULL) {
+        if (value == NULL) {
+            if (setenv(varStr, "", 1) != 0) {
+                mark_failed_with_errno(env, "could not putenv()", result);
+            }
+        } else {
+            char* valueStr = java_to_char(env, value, result);
+            if (valueStr != NULL) {
+                if (setenv(varStr, valueStr, 1) != 0) {
+                    mark_failed_with_errno(env, "could not putenv()", result);
+                }
+            }
+            free(valueStr);
         }
-    } else {
-        char* valueStr = java_to_char(env, value, result);
-        if (setenv(varStr, valueStr, 1) != 0) {
-            mark_failed_with_errno(env, "could not putenv()", result);
-        }
-        free(valueStr);
     }
     free(varStr);
 }

--- a/src/main/cpp/posix.cpp
+++ b/src/main/cpp/posix.cpp
@@ -316,25 +316,25 @@ Java_net_rubygrapefruit_platform_internal_jni_PosixProcessFunctions_setWorkingDi
 
 JNIEXPORT jstring JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_PosixProcessFunctions_getEnvironmentVariable(JNIEnv *env, jclass target, jstring var, jobject result) {
-    char* varStr = java_to_char(env, var, result);
+    char* varStr = java_to_utf_char(env, var, result);
     char* valueStr = getenv(varStr);
     free(varStr);
     if (valueStr == NULL) {
         return NULL;
     }
-    return char_to_java(env, valueStr, result);
+    return utf_char_to_java(env, valueStr, result);
 }
 
 JNIEXPORT void JNICALL
 Java_net_rubygrapefruit_platform_internal_jni_PosixProcessFunctions_setEnvironmentVariable(JNIEnv *env, jclass target, jstring var, jstring value, jobject result) {
-    char* varStr = java_to_char(env, var, result);
+    char* varStr = java_to_utf_char(env, var, result);
     if (varStr != NULL) {
         if (value == NULL) {
             if (setenv(varStr, "", 1) != 0) {
                 mark_failed_with_errno(env, "could not putenv()", result);
             }
         } else {
-            char* valueStr = java_to_char(env, value, result);
+            char* valueStr = java_to_utf_char(env, value, result);
             if (valueStr != NULL) {
                 if (setenv(varStr, valueStr, 1) != 0) {
                     mark_failed_with_errno(env, "could not putenv()", result);

--- a/src/shared/cpp/generic_posix.cpp
+++ b/src/shared/cpp/generic_posix.cpp
@@ -51,4 +51,17 @@ int map_error_code(int error_code) {
     return FAILURE_GENERIC;
 }
 
+char* java_to_utf_char(JNIEnv *env, jstring string, jobject result) {
+    size_t len = env->GetStringLength(string);
+    size_t bytes = env->GetStringUTFLength(string);
+    char* chars = (char*)malloc(bytes + 1);
+    env->GetStringUTFRegion(string, 0, len, chars);
+    chars[bytes] = 0;
+    return chars;
+}
+
+jstring utf_char_to_java(JNIEnv* env, const char* chars, jobject result) {
+    return env->NewStringUTF(chars);
+}
+
 #endif

--- a/src/shared/cpp/osx.cpp
+++ b/src/shared/cpp/osx.cpp
@@ -26,16 +26,11 @@
 #include <wchar.h>
 
 char* java_to_char(JNIEnv *env, jstring string, jobject result) {
-    size_t len = env->GetStringLength(string);
-    size_t bytes = env->GetStringUTFLength(string);
-    char* chars = (char*)malloc(bytes + 1);
-    env->GetStringUTFRegion(string, 0, len, chars);
-    chars[bytes] = 0;
-    return chars;
+    return java_to_utf_char(env, string, result);
 }
 
 jstring char_to_java(JNIEnv* env, const char* chars, jobject result) {
-    return env->NewStringUTF(chars);
+    return utf_char_to_java(env, chars, result);
 }
 
 #endif

--- a/src/shared/headers/generic.h
+++ b/src/shared/headers/generic.h
@@ -92,6 +92,20 @@ extern char* java_to_char(JNIEnv *env, jstring string, jobject result);
  */
 extern jstring char_to_java(JNIEnv* env, const char* chars, jobject result);
 
+/*
+ * Converts the given Java string to a NULL terminated char string (encoded with modified UTF-8). Should call free() when finished.
+ *
+ * Returns NULL on failure.
+ */
+extern char* java_to_utf_char(JNIEnv *env, jstring string, jobject result);
+
+/*
+ * Converts the given NULL terminated char string (encoded with modified UTF-8) to a Java string.
+ *
+ * Returns NULL on failure.
+ */
+extern jstring utf_char_to_java(JNIEnv* env, const char* chars, jobject result);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/test/groovy/net/rubygrapefruit/platform/ProcessTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/ProcessTest.groovy
@@ -125,6 +125,21 @@ class ProcessTest extends Specification {
         'TEST_ENV_VAR_NULL'  | null
     }
 
+    def "can set environment variable to supplementary character"() {
+        given:
+        String utfSupplementaryString = String.valueOf(Character.toChars(128165))
+
+        when:
+        process.setEnvironmentVariable("TEST", utfSupplementaryString)
+
+        then:
+        println System.getenv("TEST")
+        System.getenv("TEST") == utfSupplementaryString
+        System.getenv()["TEST"] == utfSupplementaryString
+        println process.getEnvironmentVariable("TEST")
+        process.getEnvironmentVariable("TEST") == utfSupplementaryString
+    }
+
     def "can remove environment variable that does not exist"() {
         assert process.getEnvironmentVariable("TEST_ENV_UNKNOWN") == null
 


### PR DESCRIPTION
This mitigates the issue by always using utf-8 encoding when getting/setting environment variables.  I feel like this is the simplest solution to the problem.  Other places where we convert, we continue to use the C-locale-dependent conversion methods, but for environment variables, we always use utf-8.

The issue with converting to bytes on the Java side and passing a byte array in is that on Windows, we don't set the environment variable using `char *`, we need `wchar *`, so if we pass in bytes then we have the opposite problem and we have to do the same conversion on windows now and potentially open ourselves to the same problem.

I also looked into doing a C-locale-dependent conversion first, and then trying the Java-byte-conversion method, but I found scenarios where this would fail.   Basically, the `setEnvironmentVariable` would fail on the C-locale-dependent conversion, we'd fallback to Java-byte-conversion, which would succeed in putting it into the environment, but then on the call to `getEnvionmentVariable` we would not fail on the C-locale-dependent conversion, it would succeed, only the result would be garbage.  It seemed safer to ensure we always convert the same way on both set/get.

There are certainly things we could do to make the Java-byte-conversion method work without needing to mess with the Windows methods, but just using the built-in utf8 conversion (for environment variables only) seemed like the safest, simplest approach. 

Let me know what you think.