### PR TITLE
Support for aarch64 on linux.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,18 @@ model {
             architecture "amd64"
             operatingSystem "linux"
         }
+        linux_aarch64 {
+            architecture "aarch64"
+            operatingSystem "linux"
+        }
+        linux_aarch64_ncurses5 {
+            architecture "aarch64"
+            operatingSystem "linux"
+        }
+        linux_aarch64_ncurses6 {
+            architecture "aarch64"
+            operatingSystem "linux"
+        }
         windows_i386 {
             architecture "i386"
             operatingSystem "windows"
@@ -154,6 +166,12 @@ model {
 
     toolChains {
         gcc(Gcc) {
+            // The core Gradle toolchain for gcc only targets x86 and x86_64 out of the box.
+            // https://github.com/gradle/gradle/blob/36614ee523e5906ddfa1fed9a5dc00a5addac1b0/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+            target("linux_aarch64")
+            target("linux_aarch64_ncurses5")
+            target("linux_aarch64_ncurses6")
+
             eachPlatform {
                 // Use GCC to build for libstdc++ on FreeBSD
                 if (platform.operatingSystem.freeBSD) {

--- a/src/main/java/net/rubygrapefruit/platform/SystemInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/SystemInfo.java
@@ -21,7 +21,7 @@ package net.rubygrapefruit.platform;
  */
 @ThreadSafe
 public interface SystemInfo extends NativeIntegration {
-    enum Architecture { i386, amd64 }
+    enum Architecture { i386, amd64, aarch64 }
 
     /**
      * Returns the name of the kernel for the current operating system.

--- a/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
@@ -44,6 +44,9 @@ public class MutableSystemInfo implements SystemInfo {
         if (machineArchitecture.equals("i386") || machineArchitecture.equals("x86") || machineArchitecture.equals("i686")) {
             return Architecture.i386;
         }
+        if (machineArchitecture.equals("aarch64")) {
+            return Architecture.aarch64;
+        }
         throw new NativeException(String.format("Cannot determine architecture from kernel architecture name '%s'.",
                 machineArchitecture));
     }

--- a/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/Platform.java
@@ -48,6 +48,8 @@ public abstract class Platform {
                         platform = new Linux64Bit();
                     } else if (arch.equals("i386") || arch.equals("x86")) {
                         platform = new Linux32Bit();
+                    } else if (arch.equals("aarch64")) {
+                        platform = new LinuxAarch64();
                     }
                 } else if (osName.contains("os x") || osName.contains("darwin")) {
                     if (arch.equals("i386")) {
@@ -281,6 +283,13 @@ public abstract class Platform {
         @Override
         public String getId() {
             return "linux-amd64";
+        }
+    }
+
+    private static class LinuxAarch64 extends Linux {
+        @Override
+        public String getId() {
+            return "linux-aarch64";
         }
     }
 


### PR DESCRIPTION
In addition to the new platform definitions, additional targets need to be explicitly added to the GCC toolchain because the core Gradle GCC toolchain only supports x86 and x86_64 out of the box.