### PR TITLE
Windows: Add support for SYMLINKS

### DIFF
--- a/src/main/java/net/rubygrapefruit/platform/file/WindowsFiles.java
+++ b/src/main/java/net/rubygrapefruit/platform/file/WindowsFiles.java
@@ -29,4 +29,9 @@ public interface WindowsFiles extends Files, NativeIntegration {
      * {@inheritDoc}
      */
     WindowsFileInfo stat(File file) throws NativeException;
+
+    /**
+     * {@inheritDoc}
+     */
+    WindowsFileInfo stat(File file, boolean linkTarget) throws NativeException;
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/DefaultWindowsFiles.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/DefaultWindowsFiles.java
@@ -28,30 +28,30 @@ import java.util.List;
 
 public class DefaultWindowsFiles extends AbstractFiles implements WindowsFiles {
     public WindowsFileInfo stat(File file) throws NativeException {
+        return stat(file, false);
+    }
+
+    public WindowsFileInfo stat(File file, boolean linkTarget) throws NativeException {
         FunctionResult result = new FunctionResult();
         WindowsFileStat stat = new WindowsFileStat(file.getPath());
-        WindowsFileFunctions.stat(file.getPath(), stat, result);
+        WindowsFileFunctions.stat(file.getPath(), linkTarget, stat, result);
         if (result.isFailed()) {
             throw new NativeException(String.format("Could not get file details of %s: %s", file, result.getMessage()));
         }
         return stat;
     }
 
-    public FileInfo stat(File file, boolean linkTarget) throws NativeException {
-        return stat(file);
-    }
-
-    public List<? extends DirEntry> listDir(File dir) throws NativeException {
+    public List<? extends DirEntry> listDir(File dir, boolean linkTarget) throws NativeException {
         FunctionResult result = new FunctionResult();
         WindowsDirList dirList = new WindowsDirList();
-        WindowsFileFunctions.readdir(dir.getPath() + "\\*", dirList, result);
+        WindowsFileFunctions.readdir(dir.getPath(), linkTarget, dirList, result);
         if (result.isFailed()) {
             throw listDirFailure(dir, result);
         }
         return dirList.files;
     }
 
-    public List<? extends DirEntry> listDir(File dir, boolean linkTarget) throws NativeException {
-        return listDir(dir);
+    public List<? extends DirEntry> listDir(File dir) throws NativeException {
+        return listDir(dir, false);
     }
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/WindowsFileFunctions.java
@@ -21,7 +21,7 @@ import net.rubygrapefruit.platform.internal.FunctionResult;
 import net.rubygrapefruit.platform.internal.WindowsFileStat;
 
 public class WindowsFileFunctions {
-    public static native void stat(String file, WindowsFileStat stat, FunctionResult result);
+    public static native void stat(String file, boolean followLink, WindowsFileStat stat, FunctionResult result);
 
-    public static native void readdir(String path, DirList dirList, FunctionResult result);
+    public static native void readdir(String path, boolean followLink, DirList dirList, FunctionResult result);
 }

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFilesTest.groovy
@@ -20,6 +20,7 @@ import net.rubygrapefruit.platform.internal.Platform
 import spock.lang.Specification
 
 import java.nio.file.LinkOption
+import java.nio.file.Paths
 import java.nio.file.attribute.BasicFileAttributeView
 import java.nio.file.attribute.BasicFileAttributes
 
@@ -37,5 +38,71 @@ class AbstractFilesTest extends Specification {
 
     void assertTimestampMatches(long statTime, long javaTime) {
         assert maybeRoundToNearestSecond(statTime) == maybeRoundToNearestSecond(javaTime)
+    }
+
+    static boolean supportsSymbolicLinks() {
+        if (!Platform.current().windows) {
+            return true
+        }
+
+        def createdFolder = File.createTempFile("junit", "")
+        createdFolder.delete()
+        createdFolder.mkdir()
+
+        def dir = createdFolder
+        def targetFile = new File(dir, "foo-dir")
+        def linkFile = new File(dir, "foo-dir.link")
+        targetFile.mkdirs()
+
+        try {
+            try {
+                createDirectorySymbolicLink(linkFile, targetFile.name)
+                return true
+            } catch(ignored) {
+                return false
+            }
+        }
+        finally {
+            targetFile.delete()
+            linkFile.delete()
+            dir.deleteDir()
+        }
+    }
+
+    private static void createSymbolicLinkHelper(File file, String linkTarget, boolean isDirectory) {
+        if (Platform.current().windows) {
+            // On Windows, we use the 'mklink' command, which works with both elevated processes
+            // and Windows 10 with developer mode enabled (see definition of the
+            // SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE flag at
+            // https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createsymboliclinkw).
+            //
+            // See https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10 for detailed
+            // information.
+            //
+            // Until the java.nio.file.Files.createSymbolicLink API support this flag, we need to resort
+            // to using the 'mklink' command. We are limited to path shorted than 260 characters though.
+            if (file.absolutePath.length() >= 260) {
+                throw new IllegalArgumentException("Error creating symbolic link: Path must be shorter than 260 characters on Windows")
+            }
+            def outputStringBuilder = new StringBuilder(), errStringBuilder = new StringBuilder()
+            def arg = isDirectory ? "/d " : ""
+            def cmd = "cmd /c mklink ${arg} \"${file.absolutePath}\" \"${linkTarget}\""
+            def process = cmd.execute()
+            process.consumeProcessOutput(outputStringBuilder, errStringBuilder)
+            process.waitForOrKill(2000)
+            if (process.exitValue() != 0) {
+                throw new IOException("Error creating symbolic link (${errStringBuilder.toString()})")
+            }
+        } else {
+            java.nio.file.Files.createSymbolicLink(file.toPath(), Paths.get(linkTarget))
+        }
+    }
+
+    static void createFileSymbolicLink(File file, String linkTarget) {
+        createSymbolicLinkHelper(file, linkTarget, false)
+    }
+
+    static void createDirectorySymbolicLink(File file, String linkTarget) {
+        createSymbolicLinkHelper(file, linkTarget, true)
     }
 }

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -41,7 +41,9 @@ public class Main {
         optionParser.accepts("cache-dir", "The directory to cache native libraries in").withRequiredArg();
         optionParser.accepts("ansi", "Force the use of ANSI escape sequences for terminal output");
         optionParser.accepts("stat", "Display details about the specified file or directory").withRequiredArg();
+        optionParser.accepts("stat-L", "Display details about the specified file or directory, following symbolic links").withRequiredArg();
         optionParser.accepts("ls", "Display contents of the specified directory").withRequiredArg();
+        optionParser.accepts("ls-L", "Display contents of the specified directory, following symbolic links").withRequiredArg();
         optionParser.accepts("watch", "Watches for changes to the specified file or directory").withRequiredArg();
         optionParser.accepts("machine", "Display details about the current machine");
         optionParser.accepts("terminal", "Display details about the terminal");
@@ -69,8 +71,18 @@ public class Main {
             return;
         }
 
+        if (result.has("stat-L")) {
+            statFollowLinks((String) result.valueOf("stat-L"));
+            return;
+        }
+
         if (result.has("ls")) {
             ls((String) result.valueOf("ls"));
+            return;
+        }
+
+        if (result.has("ls-L")) {
+            lsFollowLinks((String) result.valueOf("ls-L"));
             return;
         }
 
@@ -376,10 +388,18 @@ public class Main {
     }
 
     private static void ls(String path) {
+        ls(path, false);
+    }
+
+    private static void lsFollowLinks(String path) {
+        ls(path, true);
+    }
+
+    private static void ls(String path, boolean followLinks) {
         File dir = new File(path);
 
         Files files = Native.get(Files.class);
-        List<? extends DirEntry> entries = files.listDir(dir);
+        List<? extends DirEntry> entries = files.listDir(dir, followLinks);
         for (DirEntry entry : entries) {
             System.out.println();
             System.out.println("* Name: " + entry.getName());
@@ -389,10 +409,18 @@ public class Main {
     }
 
     private static void stat(String path) {
+        stat(path, false);
+    }
+
+    private static void statFollowLinks(String path) {
+        stat(path, true);
+    }
+
+    private static void stat(String path, boolean linkTarget) {
         File file = new File(path);
 
         Files files = Native.get(Files.class);
-        FileInfo stat = files.stat(file);
+        FileInfo stat = files.stat(file, linkTarget);
         System.out.println();
         System.out.println("* File: " + file);
         System.out.println("* Type: " + stat.getType());


### PR DESCRIPTION
Windows: Add support for SYMLINKS

* Both `stat` and `readdir` entry points support returning FILE_TYPE_SYMLINK
* Both `stat` and `readdir` entry points support the "followLink" parameter
* Add a `stat-L` option in the test app (`stat` with `followLink` option)
* Add a `ls-L` option in test app (`ls` with `followLink` option)
* Requires Windows Vista/Windows Server 2008 or later