### PR TITLE
Add system hostname

### DIFF
--- a/src/main/cpp/posix.cpp
+++ b/src/main/cpp/posix.cpp
@@ -48,6 +48,8 @@ Java_net_rubygrapefruit_platform_internal_jni_NativeLibraryFunctions_getSystemIn
     env->SetObjectField(info, osVersionField, char_to_java(env, machine_info.release, result));
     jfieldID machineArchitectureField = env->GetFieldID(infoClass, "machineArchitecture", "Ljava/lang/String;");
     env->SetObjectField(info, machineArchitectureField, char_to_java(env, machine_info.machine, result));
+    jfieldID hostnameField = env->GetFieldID(infoClass, "hostname", "Ljava/lang/String;");
+    env->SetObjectField(info, hostnameField, char_to_java(env, machine_info.nodename, result));
 }
 
 JNIEXPORT void JNICALL

--- a/src/main/cpp/win.cpp
+++ b/src/main/cpp/win.cpp
@@ -275,11 +275,19 @@ Java_net_rubygrapefruit_platform_internal_jni_NativeLibraryFunctions_getSystemIn
     } else {
         arch = env->NewStringUTF("unknown");
     }
+    
+    jstring hostname = NULL;
+    DWORD cnSize = MAX_COMPUTERNAME_LENGTH + 1;
+    wchar_t* computerName = (wchar_t*)malloc(sizeof(wchar_t) * cnSize);
+    if (GetComputerNameW(computerName, &cnSize)) {
+        hostname = wchar_to_java(env, computerName, cnSize, result);
+    }
+    free(computerName);
 
-    jmethodID method = env->GetMethodID(infoClass, "windows", "(IIIZLjava/lang/String;)V");
+    jmethodID method = env->GetMethodID(infoClass, "windows", "(IIIZLjava/lang/String;Ljava/lang/String;)V");
     env->CallVoidMethod(info, method, versionInfo.dwMajorVersion, versionInfo.dwMinorVersion,
                         versionInfo.dwBuildNumber, versionInfo.wProductType == VER_NT_WORKSTATION,
-                        arch);
+                        arch, hostname);
 }
 
 /*

--- a/src/main/java/net/rubygrapefruit/platform/SystemInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/SystemInfo.java
@@ -46,4 +46,10 @@ public interface SystemInfo extends NativeIntegration {
      */
     @ThreadSafe
     Architecture getArchitecture();
+
+    /**
+     * Returns the machine hostname, as reported by the operating system.
+     */
+    @ThreadSafe
+    String getHostname();
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/DefaultSystemInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/DefaultSystemInfo.java
@@ -47,4 +47,8 @@ public class DefaultSystemInfo implements SystemInfo {
     public Architecture getArchitecture() {
         return systemInfo.getArchitecture();
     }
+
+    public String getHostname() {
+        return systemInfo.getHostname();
+    }
 }

--- a/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
@@ -57,10 +57,11 @@ public class MutableSystemInfo implements SystemInfo {
     }
 
     // Called from native code
-    void windows(int major, int minor, int build, boolean workstation, String arch) {
+    void windows(int major, int minor, int build, boolean workstation, String arch, String host) {
         osName = toWindowsVersionName(major, minor, workstation);
         osVersion = String.format("%s.%s (build %s)", major, minor, build);
         machineArchitecture = arch;
+        hostname = host;
     }
 
     private String toWindowsVersionName(int major, int minor, boolean workstation) {

--- a/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/MutableSystemInfo.java
@@ -24,6 +24,7 @@ public class MutableSystemInfo implements SystemInfo {
     public String osName;
     public String osVersion;
     public String machineArchitecture;
+    public String hostname;
 
     public String getKernelName() {
         return osName;
@@ -35,6 +36,10 @@ public class MutableSystemInfo implements SystemInfo {
 
     public String getArchitectureName() {
         return machineArchitecture;
+    }
+
+    public String getHostname() {
+        return hostname;
     }
 
     public Architecture getArchitecture() {

--- a/src/test/groovy/net/rubygrapefruit/platform/SystemInfoTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/SystemInfoTest.groovy
@@ -35,5 +35,6 @@ class SystemInfoTest extends Specification {
         systemInfo.kernelVersion
         systemInfo.architectureName
         systemInfo.architecture
+        systemInfo.hostname
     }
 }

--- a/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
+++ b/test-app/src/main/java/net/rubygrapefruit/platform/test/Main.java
@@ -323,6 +323,7 @@ public class Main {
 
         SystemInfo systemInfo = Native.get(SystemInfo.class);
         System.out.println("* OS (Kernel): " + systemInfo.getKernelName() + ' ' + systemInfo.getKernelVersion() + ' ' + systemInfo.getArchitectureName() + " (" + systemInfo.getArchitecture() + ")");
+        System.out.println("* Hostname: " + systemInfo.getHostname());
 
         Process process = Native.get(Process.class);
         System.out.println("* PID: " + process.getProcessId());


### PR DESCRIPTION
Currently for posix systems this uses the nodename returned by uname rather than the hostname call as a) we are already calling uname and b) on MacOS and Linux these apparently return the same thing anyway.

Windows implementation will probably use GetComputerName, yet to be implemented.