### PR TITLE
Allow publishing partial snapshot variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 */build
 /out
+build-receipt.properties

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     group = 'net.rubygrapefruit'
 
     versions {
-        nextVersion = '0.19'
+        nextVersion = '0.20'
         nextSnapshot = '1'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 }
 
+boolean onlyPrimaryVariants = project.hasProperty("onlyPrimaryVariants")
+
 def nativeHeadersDir = file("$buildDir/nativeHeaders")
 
 task nativeHeaders {
@@ -294,6 +296,12 @@ model {
             }
 
             binaries.withType(SharedLibraryBinarySpec) { binary ->
+                def targetOs = binary.targetPlatform.operatingSystem
+                def targetArch = binary.targetPlatform.architecture
+                def includeVariant = !onlyPrimaryVariants || targetOs.windows || targetOs.macOsX || (targetOs.linux && targetArch.name == "x86-64" && !targetPlatform.name.contains("ncurses6"))
+                if (!includeVariant) {
+                    return
+                }
                 def variantName = targetPlatform.name.replace('_', '-')
                 variantNames << variantName
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,20 +5,21 @@ plugins {
     id 'cpp'
 }
 
+apply plugin: ReleasePlugin
+
+versions {
+    nextVersion = '0.20'
+    nextSnapshot = '1'
+}
+
 allprojects {
     apply plugin: 'java'
-    apply plugin: ReleasePlugin
 
     repositories {
         jcenter()
     }
 
     group = 'net.rubygrapefruit'
-
-    versions {
-        nextVersion = '0.20'
-        nextSnapshot = '1'
-    }
 
     sourceCompatibility = 1.5
     targetCompatibility = 1.5

--- a/buildSrc/src/main/java/BasePublishPlugin.java
+++ b/buildSrc/src/main/java/BasePublishPlugin.java
@@ -1,7 +1,6 @@
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.publish.Publication;
-import org.gradle.api.publish.maven.MavenPublication;
 
 public class BasePublishPlugin implements Plugin<Project> {
     @Override
@@ -16,7 +15,7 @@ public class BasePublishPlugin implements Plugin<Project> {
         }
     }
 
-    public static String publishTaskName(MavenPublication publication, String repository) {
+    public static String publishTaskName(Publication publication, String repository) {
         return "publish" + capitalize(publication.getName()) + "PublicationTo" + repository + "Repository";
     }
 

--- a/buildSrc/src/main/java/BasePublishPlugin.java
+++ b/buildSrc/src/main/java/BasePublishPlugin.java
@@ -1,0 +1,32 @@
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.publish.Publication;
+import org.gradle.api.publish.maven.MavenPublication;
+
+public class BasePublishPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply("maven-publish");
+        final BintrayCredentials credentials = project.getExtensions().create("bintray", BintrayCredentials.class);
+        if (project.hasProperty("bintrayUserName")) {
+            credentials.setUserName(project.property("bintrayUserName").toString());
+        }
+        if (project.hasProperty("bintrayApiKey")) {
+            credentials.setApiKey(project.property("bintrayApiKey").toString());
+        }
+    }
+
+    public static String publishTaskName(MavenPublication publication, String repository) {
+        return "publish" + capitalize(publication.getName()) + "PublicationTo" + repository + "Repository";
+    }
+
+    static String capitalize(String name) {
+        StringBuilder builder = new StringBuilder(name);
+        builder.setCharAt(0, Character.toUpperCase(builder.charAt(0)));
+        return builder.toString();
+    }
+
+    static boolean isMainPublication(Publication publication) {
+        return publication.getName().equals("main");
+    }
+}

--- a/buildSrc/src/main/java/PublishSnapshotPlugin.java
+++ b/buildSrc/src/main/java/PublishSnapshotPlugin.java
@@ -1,0 +1,35 @@
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+
+public class PublishSnapshotPlugin implements Plugin<Project> {
+    private static final String SNAPSHOT_REPOSITORY_NAME = "Snapshot";
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(BasePublishPlugin.class);
+        final BintrayCredentials credentials = project.getExtensions().getByType(BintrayCredentials.class);
+
+        project.getExtensions().configure(PublishingExtension.class, extension -> {
+            extension.getRepositories().maven(repo -> {
+                repo.setUrl(ReleasePlugin.SNAPSHOT_REPOSITORY_URL);
+                repo.setName(SNAPSHOT_REPOSITORY_NAME);
+                repo.credentials(passwordCredentials -> {
+                    passwordCredentials.setUsername(credentials.getUserName());
+                    passwordCredentials.setPassword(credentials.getApiKey());
+                });
+            });
+
+            extension.getPublications().withType(MavenPublication.class, publication -> {
+                if (!BasePublishPlugin.isMainPublication(publication)) {
+                    Task publishLifecycle = project.getTasks().maybeCreate("publishJni");
+                    publishLifecycle.setGroup("Publish");
+                    publishLifecycle.setDescription("Publish all JNI publications");
+                    publishLifecycle.dependsOn(project.getTasks().named(BasePublishPlugin.publishTaskName(publication, SNAPSHOT_REPOSITORY_NAME)));
+                }
+            });
+        });
+    }
+}

--- a/buildSrc/src/main/java/PublishSnapshotPlugin.java
+++ b/buildSrc/src/main/java/PublishSnapshotPlugin.java
@@ -1,8 +1,7 @@
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
+import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
-import org.gradle.api.publish.maven.MavenPublication;
 
 public class PublishSnapshotPlugin implements Plugin<Project> {
     private static final String SNAPSHOT_REPOSITORY_NAME = "Snapshot";
@@ -12,24 +11,19 @@ public class PublishSnapshotPlugin implements Plugin<Project> {
         project.getPlugins().apply(BasePublishPlugin.class);
         final BintrayCredentials credentials = project.getExtensions().getByType(BintrayCredentials.class);
 
-        project.getExtensions().configure(PublishingExtension.class, extension -> {
-            extension.getRepositories().maven(repo -> {
-                repo.setUrl(ReleasePlugin.SNAPSHOT_REPOSITORY_URL);
-                repo.setName(SNAPSHOT_REPOSITORY_NAME);
-                repo.credentials(passwordCredentials -> {
-                    passwordCredentials.setUsername(credentials.getUserName());
-                    passwordCredentials.setPassword(credentials.getApiKey());
-                });
-            });
+        project.getExtensions().configure(
+                PublishingExtension.class,
+                extension -> extension.getRepositories().maven(repo -> {
+                    repo.setUrl(ReleasePlugin.SNAPSHOT_REPOSITORY_URL);
+                    repo.setName(SNAPSHOT_REPOSITORY_NAME);
+                    repo.credentials(passwordCredentials -> {
+                        passwordCredentials.setUsername(credentials.getUserName());
+                        passwordCredentials.setPassword(credentials.getApiKey());
+                    });
+                }));
+    }
 
-            extension.getPublications().withType(MavenPublication.class, publication -> {
-                if (!BasePublishPlugin.isMainPublication(publication)) {
-                    Task publishLifecycle = project.getTasks().maybeCreate("publishJni");
-                    publishLifecycle.setGroup("Publish");
-                    publishLifecycle.setDescription("Publish all JNI publications");
-                    publishLifecycle.dependsOn(project.getTasks().named(BasePublishPlugin.publishTaskName(publication, SNAPSHOT_REPOSITORY_NAME)));
-                }
-            });
-        });
+    public static String uploadTaskName(Publication publication) {
+        return BasePublishPlugin.publishTaskName(publication, SNAPSHOT_REPOSITORY_NAME);
     }
 }

--- a/buildSrc/src/main/java/UploadPlugin.java
+++ b/buildSrc/src/main/java/UploadPlugin.java
@@ -2,6 +2,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.internal.ErroringAction;
@@ -33,19 +34,12 @@ public class UploadPlugin implements Plugin<Project> {
                 UpdatePackageMetadataTask update = project.getTasks().create("updatePackage" + capitalizedPublicationName, UpdatePackageMetadataTask.class);
                 update.setPublication(publication);
 
-                UploadTask upload = project.getTasks().create("uploadPackage" + capitalizedPublicationName, UploadTask.class);
+                UploadTask upload = project.getTasks().create(uploadTaskName(publication), UploadTask.class);
                 upload.setGroup("Upload");
                 upload.setDescription("Upload publication " + publication.getName());
                 upload.setLocalRepoDir(repoDir);
                 upload.setPublication(publication);
                 upload.dependsOn(update);
-                if (!BasePublishPlugin.isMainPublication(publication)) {
-                    Task uploadLifecycle = project.getTasks().maybeCreate("uploadJni");
-                    uploadLifecycle.setGroup("Upload");
-                    uploadLifecycle.setDescription("Upload all JNI publications");
-                    uploadLifecycle.dependsOn(upload);
-                }
-
             });
         });
         project.getGradle().getTaskGraph().whenReady(graph -> {
@@ -58,5 +52,9 @@ public class UploadPlugin implements Plugin<Project> {
                 }
             }
         });
+    }
+
+    public static String uploadTaskName(Publication publication) {
+        return "uploadPackage" + BasePublishPlugin.capitalize(publication.getName());
     }
 }

--- a/buildSrc/src/main/java/UploadPlugin.java
+++ b/buildSrc/src/main/java/UploadPlugin.java
@@ -1,9 +1,7 @@
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.internal.ErroringAction;
@@ -16,64 +14,47 @@ import java.util.concurrent.Callable;
  * handle multiple packages per project.
  */
 public class UploadPlugin implements Plugin<Project> {
+
     @Override
     public void apply(final Project project) {
-        project.getPlugins().apply("maven-publish");
-        final BintrayCredentials credentials = project.getExtensions().create("bintray", BintrayCredentials.class);
-        if (project.hasProperty("bintrayUserName")) {
-            credentials.setUserName(project.property("bintrayUserName").toString());
-        }
-        if (project.hasProperty("bintrayApiKey")) {
-            credentials.setApiKey(project.property("bintrayApiKey").toString());
-        }
+        project.getPlugins().apply(BasePublishPlugin.class);
+        final BintrayCredentials credentials = project.getExtensions().getByType(BintrayCredentials.class);
 
-        final Callable<File> repoDir = new Callable<File>() {
-            public File call() {
-                return project.getRootProject().getLayout().getBuildDirectory().dir("repo").get().getAsFile();
-            }
-        };
-        project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
-            @Override
-            public void execute(PublishingExtension extension) {
-                extension.getRepositories().maven(new ErroringAction<MavenArtifactRepository>() {
-                    @Override
-                    public void doExecute(MavenArtifactRepository repo) throws Exception {
-                        repo.setUrl(repoDir.call());
-                    }
-                });
-                extension.getPublications().withType(MavenPublication.class, new Action<MavenPublication>() {
-                    @Override
-                    public void execute(MavenPublication publication) {
-                        UpdatePackageMetadataTask update = project.getTasks().create("updatePackage" + UploadTask.capitalize(publication.getName()), UpdatePackageMetadataTask.class);
-                        update.setPublication(publication);
+        final Callable<File> repoDir = () -> project.getRootProject().getLayout().getBuildDirectory().dir("repo").get().getAsFile();
+        project.getExtensions().configure(PublishingExtension.class, extension -> {
+            extension.getRepositories().maven(new ErroringAction<MavenArtifactRepository>() {
+                @Override
+                public void doExecute(MavenArtifactRepository repo) throws Exception {
+                    repo.setUrl(repoDir.call());
+                }
+            });
+            extension.getPublications().withType(MavenPublication.class, publication -> {
+                String capitalizedPublicationName = BasePublishPlugin.capitalize(publication.getName());
+                UpdatePackageMetadataTask update = project.getTasks().create("updatePackage" + capitalizedPublicationName, UpdatePackageMetadataTask.class);
+                update.setPublication(publication);
 
-                        UploadTask upload = project.getTasks().create("uploadPackage" + UploadTask.capitalize(publication.getName()), UploadTask.class);
-                        upload.setGroup("Upload");
-                        upload.setDescription("Upload publication " + publication.getName());
-                        upload.setLocalRepoDir(repoDir);
-                        upload.setPublication(publication);
-                        upload.dependsOn(update);
-                        if (!publication.getName().equals("main")) {
-                            Task uploadLifecycle = project.getTasks().maybeCreate("uploadJni");
-                            uploadLifecycle.setGroup("Upload");
-                            uploadLifecycle.setDescription("Upload all JNI publications");
-                            uploadLifecycle.dependsOn(upload);
-                        }
+                UploadTask upload = project.getTasks().create("uploadPackage" + capitalizedPublicationName, UploadTask.class);
+                upload.setGroup("Upload");
+                upload.setDescription("Upload publication " + publication.getName());
+                upload.setLocalRepoDir(repoDir);
+                upload.setPublication(publication);
+                upload.dependsOn(update);
+                if (!BasePublishPlugin.isMainPublication(publication)) {
+                    Task uploadLifecycle = project.getTasks().maybeCreate("uploadJni");
+                    uploadLifecycle.setGroup("Upload");
+                    uploadLifecycle.setDescription("Upload all JNI publications");
+                    uploadLifecycle.dependsOn(upload);
+                }
 
-                    }
-                });
-            }
+            });
         });
-        project.getGradle().getTaskGraph().whenReady(new Action<TaskExecutionGraph>() {
-            @Override
-            public void execute(TaskExecutionGraph graph) {
-                for (Task task : graph.getAllTasks()) {
-                    if (task instanceof BintrayTask) {
-                        credentials.assertPresent();
-                        BintrayTask bintrayTask = (BintrayTask) task;
-                        bintrayTask.setUserName(credentials.getUserName());
-                        bintrayTask.setApiKey(credentials.getApiKey());
-                    }
+        project.getGradle().getTaskGraph().whenReady(graph -> {
+            for (Task task : graph.getAllTasks()) {
+                if (task instanceof BintrayTask) {
+                    credentials.assertPresent();
+                    BintrayTask bintrayTask = (BintrayTask) task;
+                    bintrayTask.setUserName(credentials.getUserName());
+                    bintrayTask.setApiKey(credentials.getApiKey());
                 }
             }
         });

--- a/buildSrc/src/main/java/UploadTask.java
+++ b/buildSrc/src/main/java/UploadTask.java
@@ -17,7 +17,7 @@ public class UploadTask extends BintrayTask {
         dependsOn(new Callable<Task>() {
             @Override
             public Task call() {
-                return getProject().getTasks().getByName("publish" + capitalize(publication.getName()) + "PublicationToMavenRepository");
+                return getProject().getTasks().getByName(BasePublishPlugin.publishTaskName(publication, "Maven"));
             }
         });
     }
@@ -73,11 +73,5 @@ public class UploadTask extends BintrayTask {
 
     private URI uploadUrl(String groupId, String artifactId, String mavenPath) throws URISyntaxException {
         return new URI("https://api.bintray.com/maven/adammurdoch/maven/" + groupId + ":" + artifactId + "/" + mavenPath);
-    }
-
-    static String capitalize(String name) {
-        StringBuilder builder = new StringBuilder(name);
-        builder.setCharAt(0, Character.toUpperCase(builder.charAt(0)));
-        return builder.toString();
     }
 }

--- a/buildSrc/src/main/java/VersionDetails.java
+++ b/buildSrc/src/main/java/VersionDetails.java
@@ -3,7 +3,7 @@ import javax.inject.Inject;
 public class VersionDetails {
 
     public enum BuildType {
-        Dev, Milestone, Release
+        Dev, Snapshot, Milestone, Release
     }
 
     private String nextVersion;


### PR DESCRIPTION
This PR allows publishing snapshots, which use a timestamped version number. Moreover, it is possible to publish snapshots with fewer supported OSes to the Gradle snapshot repository.