### PR TITLE
Handle locking file event on macOS

### DIFF
--- a/src/main/cpp/apple_fsnotifier.cpp
+++ b/src/main/cpp/apple_fsnotifier.cpp
@@ -86,6 +86,9 @@ static void callback(ConstFSEventStreamRef streamRef,
             type = FILE_EVENT_REMOVED;
         } else if (IS_SET(flags, kFSEventStreamEventFlagItemCreated)) {
             type = FILE_EVENT_CREATED;
+        } else if (IS_SET(flags, kFSEventStreamEventFlagItemInodeMetaMod)) {
+            // File locked
+            type = FILE_EVENT_MODIFIED;
         } else {
             printf("~~~~ Unknown event 0x%x for %s\n", flags, paths[i]);
             type = FILE_EVENT_UNKNOWN;

--- a/src/main/java/net/rubygrapefruit/platform/internal/jni/NativeLibraryFunctions.java
+++ b/src/main/java/net/rubygrapefruit/platform/internal/jni/NativeLibraryFunctions.java
@@ -21,7 +21,7 @@ import net.rubygrapefruit.platform.internal.MutableSystemInfo;
 import net.rubygrapefruit.platform.terminal.Terminals;
 
 public class NativeLibraryFunctions {
-    public static final int VERSION = 35;
+    public static final int VERSION = 36;
 
     public static final int STDOUT = Terminals.Output.Stdout.ordinal();
     public static final int STDERR = Terminals.Output.Stderr.ordinal();

--- a/src/shared/headers/generic.h
+++ b/src/shared/headers/generic.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#define NATIVE_VERSION 35
+#define NATIVE_VERSION 36
 
 // Corresponds to NativeLibraryFunctions constants
 #define STDOUT_DESCRIPTOR 0


### PR DESCRIPTION
When Gradle locks a file, the macOS watchers receive a `0x10400`event. That is `kFSEventStreamEventFlagItemInodeMetaMod | kFSEventStreamEventFlagItemIsFile `.

This currently causes Gradle to drop the whole VFS state when used on the `gradle/gradle` build.

This PR hands on the change as `MODIFIED` to the Java side. Another option would be to completely ignore the event.