### PR TITLE
Better JNI thread management

### DIFF
--- a/src/main/cpp/apple_fsnotifier.cpp
+++ b/src/main/cpp/apple_fsnotifier.cpp
@@ -20,7 +20,7 @@ typedef struct watch_details {
     CFMutableArrayRef rootsToWatch;
     FSEventStreamRef watcherStream;
     pthread_t watcherThread;
-    JavaVM* jvm;
+    JavaVM *jvm;
     JNIEnv *env;
     jobject watcherCallback;
     CFRunLoopRef threadLoop;

--- a/src/main/cpp/apple_fsnotifier.cpp
+++ b/src/main/cpp/apple_fsnotifier.cpp
@@ -167,21 +167,23 @@ Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatchin
     printf("\n~~~~ Configuring...\n");
 
     invalidStateDetected = false;
-    CFMutableArrayRef rootsToWatch = CFArrayCreateMutable(NULL, 0, NULL);
-    if (rootsToWatch == NULL) {
-        mark_failed_with_errno(env, "Could not allocate array to store roots to watch.", result);
+
+    JavaVM* jvm;
+    int jvmStatus = env->GetJavaVM(&jvm);
+    if (jvmStatus < 0) {
+        mark_failed_with_errno(env, "Could not store jvm instance.", result);
         return NULL;
     }
+
     int count = env->GetArrayLength(paths);
     if (count == 0) {
         mark_failed_with_errno(env, "No paths given to watch.", result);
         return NULL;
     }
 
-    JavaVM* jvm;
-    int jvmStatus = env->GetJavaVM(&jvm);
-    if (jvmStatus < 0) {
-        mark_failed_with_errno(env, "Could not store jvm instance.", result);
+    CFMutableArrayRef rootsToWatch = CFArrayCreateMutable(NULL, 0, NULL);
+    if (rootsToWatch == NULL) {
+        mark_failed_with_errno(env, "Could not allocate array to store roots to watch.", result);
         return NULL;
     }
 

--- a/src/main/cpp/win_fsnotifier.cpp
+++ b/src/main/cpp/win_fsnotifier.cpp
@@ -7,11 +7,11 @@
 #include "generic.h"
 #include "win.h"
 
-JavaVM* jvm = NULL;
-
 typedef struct watch_details {
     HANDLE threadHandle;
     HANDLE stopEventHandle;
+    JavaVM *jvm;
+    JNIEnv *env;
     wchar_t drivePath[4];
     int watchedPathCount;
     wchar_t **watchedPaths;
@@ -27,21 +27,7 @@ typedef struct watch_details {
                     FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_WRITE)
 
 void reportEvent(jint type, wchar_t *changedPath, int changedPathLen, watch_details_t *details) {
-    JNIEnv* env;
-    int getEnvStat = jvm->GetEnv((void **)&env, JNI_VERSION_1_6);
-    if (getEnvStat == JNI_EDETACHED) {
-        int attachThreadStat = jvm->AttachCurrentThread((void **) &env, NULL);
-        if (attachThreadStat != JNI_OK) {
-            printf("~~~~ Problem with AttachCurrentThread: %d\n", attachThreadStat);
-            // TODO Error handling
-            return;
-        }
-    } else if (getEnvStat == JNI_EVERSION) {
-        printf("~~~~ Problem with GetEnv: %d\n", getEnvStat);
-        // TODO Error handling
-        return;
-    }
-
+    JNIEnv *env = details->env;
     jobject watcherCallback = details->watcherCallback;
     jstring changedPathJava = wchar_to_java(env, changedPath, changedPathLen, NULL);
     jclass callback_class = env->GetObjectClass(watcherCallback);
@@ -90,6 +76,14 @@ DWORD WINAPI EventProcessingThread(LPVOID data) {
     watch_details_t *details = (watch_details_t*) data;
 
     printf("~~~~ Starting thread\n");
+
+    // TODO Extract this logic to some shared function
+    JavaVM* jvm = details->jvm;
+    jint statAttach = jvm->AttachCurrentThreadAsDaemon((void **) &(details->env), NULL);
+    if (statAttach != JNI_OK) {
+        printf("Failed to attach JNI to current thread: %d\n", statAttach);
+        return 0;
+    }
 
     OVERLAPPED overlapped;
     memset(&overlapped, 0, sizeof(overlapped));
@@ -141,6 +135,14 @@ DWORD WINAPI EventProcessingThread(LPVOID data) {
 
     CloseHandle(overlapped.hEvent);
     CloseHandle(hDrive);
+
+    // TODO Extract this logic to some shared function
+    jint statDetach = jvm->DetachCurrentThread();
+    if (statDetach != JNI_OK) {
+        printf("Failed to detach JNI from current thread: %d\n", statAttach);
+        return 0;
+    }
+
     return 0;
 }
 
@@ -149,9 +151,9 @@ Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWat
 
     printf("\n~~~~ Configuring...\n");
 
-    // TODO Should this be somewhere global?
+    JavaVM* jvm;
     int jvmStatus = env->GetJavaVM(&jvm);
-    if (jvmStatus < 0) {
+    if (jvmStatus != JNI_OK) {
         mark_failed_with_errno(env, "Could not store jvm instance.", result);
         return NULL;
     }
@@ -191,6 +193,7 @@ Java_net_rubygrapefruit_platform_internal_jni_WindowsFileEventFunctions_startWat
     watch_details_t* details = (watch_details_t*)malloc(sizeof(watch_details_t));
     details->watcherCallback = env->NewGlobalRef(javaCallback);
     details->stopEventHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
+    details->jvm = jvm;
     details->watchedPathCount = watchedPathCount;
     details->watchedPaths = watchedPaths;
     wcscpy_s(details->drivePath, 4, drivePath);


### PR DESCRIPTION
Instead of trying to attach the thread to the JVM every time we report a change, we only attach it when the thread starts and detach it at the end so the JVM can exit.

Fixes https://github.com/adammurdoch/native-platform/issues/56.