### PR TITLE
macOS handle watched directory hierarchy deleted event

### DIFF
--- a/src/main/cpp/apple_fsnotifier.cpp
+++ b/src/main/cpp/apple_fsnotifier.cpp
@@ -79,6 +79,8 @@ static void callback(ConstFSEventStreamRef streamRef,
         } else if (IS_SET(flags, kFSEventStreamEventFlagItemInodeMetaMod)) {
             // File locked
             type = FILE_EVENT_MODIFIED;
+        } else if (IS_SET(flags, kFSEventStreamEventFlagRootChanged)) {
+            type = FILE_EVENT_REMOVED;
         } else {
             printf("~~~~ Unknown event 0x%x for %s\n", flags, paths[i]);
             type = FILE_EVENT_UNKNOWN;
@@ -225,7 +227,7 @@ Java_net_rubygrapefruit_platform_internal_jni_OsxFileEventFunctions_startWatchin
                 rootsToWatch,
                 kFSEventStreamEventIdSinceNow,
                 latencyInMillis / 1000.0,
-                kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents);
+                kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagWatchRoot);
     if (details->watcherStream == NULL) {
         mark_failed_with_errno(env, "Could not create FSEventStreamCreate to track changes.", result);
         freeDetails(env, details);

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
@@ -354,6 +354,7 @@ abstract class AbstractFileEventsTest extends Specification {
     }
 
     @Unroll
+    @IgnoreIf({ Platform.current().windows })
     def "can detect #removedAncestry removed"() {
         given:
         def parentDir = new File(rootDir, "parent")

--- a/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/AbstractFileEventsTest.groovy
@@ -32,10 +32,10 @@ abstract class AbstractFileEventsTest extends Specification {
     @Rule
     TemporaryFolder tmpDir
     def callback = new TestCallback()
-    File dir
+    File rootDir
 
     def setup() {
-        dir = tmpDir.newFolder()
+        rootDir = tmpDir.newFolder()
     }
 
     def cleanup() {
@@ -44,7 +44,7 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can open and close watcher on a directory without receiving any events"() {
         when:
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         then:
         noExceptionThrown()
@@ -52,8 +52,8 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can detect file created"() {
         given:
-        def createdFile = new File(dir, "created.txt")
-        startWatcher(dir)
+        def createdFile = new File(rootDir, "created.txt")
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents created(createdFile)
@@ -65,13 +65,13 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can detect file removed"() {
         given:
-        def removedFile = new File(dir, "removed.txt")
+        def removedFile = new File(rootDir, "removed.txt")
         removedFile.createNewFile()
         // TODO Why does Windows report the modification?
         def expectedEvents = Platform.current().windows
             ? [modified(removedFile), removed(removedFile)]
             : [removed(removedFile)]
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents expectedEvents
@@ -83,9 +83,9 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can detect file modified"() {
         given:
-        def modifiedFile = new File(dir, "modified.txt")
+        def modifiedFile = new File(rootDir, "modified.txt")
         modifiedFile.createNewFile()
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents modified(modifiedFile)
@@ -97,14 +97,14 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can detect file renamed"() {
         given:
-        def sourceFile = new File(dir, "source.txt")
-        def targetFile = new File(dir, "target.txt")
+        def sourceFile = new File(rootDir, "source.txt")
+        def targetFile = new File(rootDir, "target.txt")
         sourceFile.createNewFile()
         // TODO Why doesn't Windows report the creation of the target file?
         def expectedEvents = Platform.current().windows
             ? [removed(sourceFile)]
             : [removed(sourceFile), created(targetFile)]
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents expectedEvents
@@ -117,10 +117,10 @@ abstract class AbstractFileEventsTest extends Specification {
     def "can detect file moved out"() {
         given:
         def outsideDir = tmpDir.newFolder()
-        def sourceFileInside = new File(dir, "source-inside.txt")
+        def sourceFileInside = new File(rootDir, "source-inside.txt")
         def targetFileOutside = new File(outsideDir, "target-outside.txt")
         sourceFileInside.createNewFile()
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents removed(sourceFileInside)
@@ -134,9 +134,9 @@ abstract class AbstractFileEventsTest extends Specification {
         given:
         def outsideDir = tmpDir.newFolder()
         def sourceFileOutside = new File(outsideDir, "source-outside.txt")
-        def targetFileInside = new File(dir, "target-inside.txt")
+        def targetFileInside = new File(rootDir, "target-inside.txt")
         sourceFileOutside.createNewFile()
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents created(targetFileInside)
@@ -148,9 +148,9 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can receive multiple events from the same directory"() {
         given:
-        def firstFile = new File(dir, "first.txt")
-        def secondFile = new File(dir, "second.txt")
-        startWatcher(dir)
+        def firstFile = new File(rootDir, "first.txt")
+        def secondFile = new File(rootDir, "second.txt")
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents created(firstFile)
@@ -170,10 +170,10 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "does not receive events from unwatched directory"() {
         given:
-        def watchedFile = new File(dir, "watched.txt")
+        def watchedFile = new File(rootDir, "watched.txt")
         def unwatchedDir = tmpDir.newFolder()
         def unwatchedFile = new File(unwatchedDir, "unwatched.txt")
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents created(watchedFile)
@@ -186,10 +186,10 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can receive multiple events from multiple watched directories"() {
         given:
-        def firstFileInFirstWatchedDir = new File(dir, "first-watched.txt")
+        def firstFileInFirstWatchedDir = new File(rootDir, "first-watched.txt")
         def secondWatchedDir = tmpDir.newFolder()
         def secondFileInSecondWatchedDir = new File(secondWatchedDir, "sibling-watched.txt")
-        startWatcher(dir, secondWatchedDir)
+        startWatcher(rootDir, secondWatchedDir)
 
         when:
         def expectedChanges = expectEvents created(firstFileInFirstWatchedDir)
@@ -208,8 +208,8 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can receive events from directory with different casing"() {
         given:
-        def lowercaseDir = new File(dir, "watch-this")
-        def uppercaseDir = new File(dir, "WATCH-THIS")
+        def lowercaseDir = new File(rootDir, "watch-this")
+        def uppercaseDir = new File(rootDir, "WATCH-THIS")
         def fileInLowercaseDir = new File(lowercaseDir, "lowercase.txt")
         def fileInUppercaseDir = new File(uppercaseDir, "UPPERCASE.TXT")
         uppercaseDir.mkdirs()
@@ -235,7 +235,7 @@ abstract class AbstractFileEventsTest extends Specification {
     def "can handle exception in callback"() {
         given:
         def error = new RuntimeException("Error")
-        def createdFile = new File(dir, "created.txt")
+        def createdFile = new File(rootDir, "created.txt")
         def conditions = new AsyncConditions()
         when:
         startWatcher({ type, path ->
@@ -244,7 +244,7 @@ abstract class AbstractFileEventsTest extends Specification {
             } finally {
                 conditions.evaluate {}
             }
-        }, dir)
+        }, rootDir)
         createdFile.createNewFile()
         conditions.await()
 
@@ -254,7 +254,7 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can be started once and stopped multiple times"() {
         given:
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         // TODO There's a race condition in starting the macOS watcher thread
@@ -268,9 +268,9 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can be used multiple times"() {
         given:
-        def firstFile = new File(dir, "first.txt")
-        def secondFile = new File(dir, "second.txt")
-        startWatcher(dir)
+        def firstFile = new File(rootDir, "first.txt")
+        def secondFile = new File(rootDir, "second.txt")
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents created(firstFile)
@@ -281,7 +281,7 @@ abstract class AbstractFileEventsTest extends Specification {
         stopWatcher()
 
         when:
-        startWatcher(dir)
+        startWatcher(rootDir)
         expectedChanges = expectEvents created(secondFile)
         secondFile.createNewFile()
 
@@ -291,10 +291,10 @@ abstract class AbstractFileEventsTest extends Specification {
 
     def "can receive event about a non-direct descendant change"() {
         given:
-        def subDir = new File(dir, "sub-dir")
+        def subDir = new File(rootDir, "sub-dir")
         subDir.mkdirs()
         def fileInSubDir = new File(subDir, "watched-descendant.txt")
-        startWatcher(dir)
+        startWatcher(rootDir)
 
         when:
         def expectedChanges = expectEvents created(fileInSubDir)
@@ -308,7 +308,7 @@ abstract class AbstractFileEventsTest extends Specification {
     @IgnoreIf({ Platform.current().windows })
     def "can watch directory with long path"() {
         given:
-        def subDir = new File(dir, "long-path")
+        def subDir = new File(rootDir, "long-path")
         4.times {
             subDir = new File(subDir, "X" * 200)
         }
@@ -329,7 +329,7 @@ abstract class AbstractFileEventsTest extends Specification {
         Assume.assumeTrue(supported)
 
         given:
-        def subDir = new File(dir, path)
+        def subDir = new File(rootDir, path)
         subDir.mkdirs()
         def fileInSubDir = new File(subDir, path)
         startWatcher(subDir)

--- a/src/test/groovy/net/rubygrapefruit/platform/file/WindowsFileEventFunctionsTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/platform/file/WindowsFileEventFunctionsTest.groovy
@@ -34,7 +34,7 @@ class WindowsFileEventFunctionsTest extends AbstractFileEventsTest {
 
     def "cannot watch long paths"() {
         given:
-        def longPath = new File(dir, "X" * 240).canonicalPath
+        def longPath = new File(rootDir, "X" * 240).canonicalPath
         when:
         fileEvents.startWatching([longPath]) {}
 


### PR DESCRIPTION
We didn't handle the event when a watched directory was deleted in its entirety. Now we do.